### PR TITLE
Check for queues[key]

### DIFF
--- a/lib/caching.js
+++ b/lib/caching.js
@@ -28,9 +28,11 @@ module.exports = function Caching(store) {
                 work(function () {
                     var args = Array.prototype.slice.call(arguments, 0);
                     store.set(key, ttl, args);
-                    queues[key].forEach(function (done) {
-                        done.apply(null, args);
-                    });
+                    if (typeof queues[key] !== 'undefined' && queues[key] !== null) {
+                        queues[key].forEach(function (done) {
+                            done.apply(null, args);
+                        });
+                    }
                     delete queues[key];
                 });
             }


### PR DESCRIPTION
# Why

Handle type error when a key is not defined
# Error

```
Debug: internal, implementation, error
    TypeError: Cannot read property 'forEach' of undefined
    at /Users/c-expansion-mtrujill/dev/cnn-weather/node_modules/cnn-caching/lib/caching.js:31:32
    at /Users/c-expansion-mtrujill/dev/cnn-weather/routes/index.js:135:25
    at executeCallback (/Users/c-expansion-mtrujill/dev/cnn-weather/modules/forecast.js:359:9)
    at Request._callback (/Users/c-expansion-mtrujill/dev/cnn-weather/modules/forecast.js:318:9)
    at Request.self.callback (/Users/c-expansion-mtrujill/dev/cnn-weather/node_modules/request/request.js:200:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/Users/c-expansion-mtrujill/dev/cnn-weather/node_modules/request/request.js:1067:10)
    at emitOne (events.js:101:20)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/Users/c-expansion-mtrujill/dev/cnn-weather/node_modules/request/request.js:988:12)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:926:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```
