### PR TITLE
update deps to reduce tech debt

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "hashring": "3.2.0",
-    "hiredis": "0.4.1",
-    "redis": "2.6.0-1"
+    "hiredis": "0.5.0",
+    "redis": "2.6.2"
   },
   "devDependencies": {
     "expresso": "0.9.2",


### PR DESCRIPTION
# Why

Updating dependencies in order to reduce tech debt:

hiredis: 0.5.0
redis: 2.6.2
