### PR TITLE
Add minTtl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ setInterval(function() {
 var Caching = require('cnn-caching');
 var cache = new Caching('hashring', {
         "servers": 'http://localhost:6377,http://localhost:6378,http://localhost:6379,http://localhost:6380',
-        "max cache size": 10000 /* Any node-hashing options allowed */
+        "max cache size": 10000,  /* Any node-hashing options allowed */
+        "minTtl": 10  /* Minimum TTL that cnn-caching will actually cache (default 0) */
     });
 
 setInterval(function() {

--- a/lib/caching.js
+++ b/lib/caching.js
@@ -7,7 +7,7 @@ module.exports = function Caching(store) {
         queues = {},
         cacher;
 
-    if (typeof store == 'string') {
+    if (typeof store === 'string') {
         try {
             path = util.format('./stores/%s', store.toLowerCase().trim());
             store = require(path)(arguments[1]);

--- a/lib/stores/hashring.js
+++ b/lib/stores/hashring.js
@@ -6,11 +6,12 @@ var url = require('url'),
     util = require('util');
 
 function HashRingStore(options) {
-
     var i,
         temp,
         servers,
         message;
+
+    options = options || {};
 
     if (!(this instanceof HashRingStore)) {
         return new HashRingStore(options);
@@ -37,6 +38,7 @@ function HashRingStore(options) {
 
     this.ring = new HashRing(servers, 'md5', options);
     this.client = {};
+    this.minTtl = (typeof options.minTtl === 'number' && options.minTtl > 0) ? options.minTtl : 0;
 
     for (i = 0; i < servers.length; i++) {
         temp = url.parse(servers[i]);
@@ -60,7 +62,9 @@ HashRingStore.prototype.get = function (key, callback) {
 
 HashRingStore.prototype.set = function (key, ttl, result) {
     if (ttl) {
-        this.getClient(key).setex(key, Math.ceil(ttl / 1000), JSON.stringify(result));
+        if (ttl > this.minTtl) {
+            this.getClient(key).setex(key, Math.ceil(ttl / 1000), JSON.stringify(result));
+        } // else do nothing, not above minTtl threshold for caching!!!
     } else {
         this.getClient(key).set(key, JSON.stringify(result));
     }

--- a/lib/stores/hashring.js
+++ b/lib/stores/hashring.js
@@ -62,7 +62,7 @@ HashRingStore.prototype.get = function (key, callback) {
 
 HashRingStore.prototype.set = function (key, ttl, result) {
     if (ttl) {
-        if (ttl > this.minTtl) {
+        if (ttl >= this.minTtl) {
             this.getClient(key).setex(key, Math.ceil(ttl / 1000), JSON.stringify(result));
         } // else do nothing, not above minTtl threshold for caching!!!
     } else {

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -17,7 +17,7 @@ MemoryStore.prototype.get = function (key, callback) {
 MemoryStore.prototype.set = function (key, ttl, result) {
     var self = this;
     if (ttl) {
-        if (ttl > self.minTtl) {
+        if (ttl >= self.minTtl) {
             self.cache[key] = result;
             setTimeout(function () {
                 delete self.cache[key];

--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -1,9 +1,10 @@
-function MemoryStore() {
+function MemoryStore(opts) {
     if (!(this instanceof MemoryStore)) {
         return new MemoryStore;
     }
 
     this.cache = {};
+    this.minTtl = (opts && typeof opts.minTtl === 'number' && opts.minTtl > 0) ? opts.minTtl : 0;
 }
 
 MemoryStore.prototype.get = function (key, callback) {
@@ -14,12 +15,16 @@ MemoryStore.prototype.get = function (key, callback) {
 };
 
 MemoryStore.prototype.set = function (key, ttl, result) {
-    this.cache[key] = result;
+    var self = this;
     if (ttl) {
-        var self = this;
-        setTimeout(function () {
-            delete self.cache[key];
-        }, ttl);
+        if (ttl > self.minTtl) {
+            self.cache[key] = result;
+            setTimeout(function () {
+                delete self.cache[key];
+            }, ttl);
+        } // else do nothing, not above minTtl threshold for caching!!!
+    } else {
+        self.cache[key] = result;
     }
 };
 

--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -20,7 +20,7 @@ RedisStore.prototype.get = function (key, callback) {
 
 RedisStore.prototype.set = function (key, ttl, result) {
     if (ttl) {
-        if (ttl > this.minTtl) {
+        if (ttl >= this.minTtl) {
             this.client.setex(key, Math.ceil(ttl / 1000), JSON.stringify(result));
         } // else do nothing, not above minTtl threshold for caching!!!
     } else {

--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -5,8 +5,10 @@ function RedisStore(opts) {
 
     if (typeof opts === 'undefined') {
         this.client = require('redis').createClient();
+        this.minTtl = 0;
     } else {
         this.client = require('redis').createClient(opts.port, opts.host, opts);
+        this.minTtl = (typeof opts.minTtl === 'number' && opts.minTtl > 0) ? opts.minTtl : 0;
     }
 }
 
@@ -18,7 +20,9 @@ RedisStore.prototype.get = function (key, callback) {
 
 RedisStore.prototype.set = function (key, ttl, result) {
     if (ttl) {
-        this.client.setex(key, Math.ceil(ttl / 1000), JSON.stringify(result));
+        if (ttl > this.minTtl) {
+            this.client.setex(key, Math.ceil(ttl / 1000), JSON.stringify(result));
+        } // else do nothing, not above minTtl threshold for caching!!!
     } else {
         this.client.set(key, JSON.stringify(result));
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnn-caching",
   "description": "Easier caching in node.js. Now with consistent hashing.",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "main": "./lib/caching",
   "directories": {
     "lib": "./lib"
@@ -20,17 +20,17 @@
   },
   "homepage": "https://github.com/cnnlabs/cnn-caching#readme",
   "engines": {
-    "node": ">=0.10.42"
+    "node": ">=4.4.7"
   },
   "dependencies": {
     "hashring": "3.2.0",
     "hiredis": "0.5.0",
-    "redis": "2.6.2"
+    "redis": "2.7.1"
   },
   "devDependencies": {
-    "changelog-maker": "2.2.3",
+    "changelog-maker": "2.2.5",
     "expresso": "0.9.2",
-    "nock": "8.0.0"
+    "nock": "9.0.13"
   },
   "keywords": [
     "cnn",

--- a/test/test-caching.js
+++ b/test/test-caching.js
@@ -200,7 +200,7 @@ exports.RedisStore = function (beforeExit) {
         assert.ifError(err);
         assert.equal(typeof results, 'number');
         assert.ok(!wroteCache);
-        redisCache.store.client.end();
+        redisCache.store.client.end(true);
     });
 
     beforeExit(function () {
@@ -242,7 +242,7 @@ exports['RedisStore expiration'] = function (beforeExit) {
             assert.ifError(err);
             assert.equal(typeof results, 'number');
             assert.ok(wroteCache);
-            redisCache.store.client.end();
+            redisCache.store.client.end(true);
         });
     }, ttl * 2);
 
@@ -285,7 +285,7 @@ exports['RedisStore removal'] = function (beforeExit) {
                 assert.ifError(err);
                 assert.equal(typeof results, 'number');
                 assert.ok(wroteCache);
-                redisCache.store.client.end();
+                redisCache.store.client.end(true);
             });
         }, 50);
     });
@@ -329,7 +329,7 @@ exports['RedisStore removal pattern'] = function (beforeExit) {
                 assert.ifError(err);
                 assert.equal(typeof results, 'number');
                 assert.ok(wroteCache);
-                redisCache.store.client.end();
+                redisCache.store.client.end(true);
             });
         }, 50);
     });


### PR DESCRIPTION
This adds a "minTtl" option that can be used to effectively not cache anything below the "minTtl" threshold.  This can be useful if you want to maintain general caching and do connection caching, but not cache anything with an extremely low TTL.